### PR TITLE
Combine circle detection scripts with grid overlay

### DIFF
--- a/find_all_circles.py
+++ b/find_all_circles.py
@@ -2,68 +2,61 @@ from pathlib import Path
 import cv2
 import numpy as np
 
+from find_center_circle import (
+    find_center_circle,
+    draw_grid,
+    detect_all_circles,
+)
 
-def draw_crosshair(img: np.ndarray, center: tuple[int, int], size: int = 5, color: tuple[int, int, int] = (0, 0, 255)) -> None:
-    """Draw a simple crosshair centered at ``center`` on ``img``.
 
-    Parameters
-    ----------
-    img: numpy.ndarray
-        Image on which to draw.
-    center: tuple[int, int]
-        (x, y) pixel location of the crosshair center.
-    size: int
-        Half-length of each crosshair arm in pixels.
-    color: tuple[int, int, int]
-        BGR colour for the crosshair.
-    """
+def draw_crosshair(
+    img: np.ndarray,
+    center: tuple[int, int],
+    size: int = 5,
+    color: tuple[int, int, int] = (0, 0, 255),
+) -> None:
+    """Draw a simple crosshair centered at ``center`` on ``img``."""
+
     x, y = center
     cv2.line(img, (x - size, y), (x + size, y), color, 1)
     cv2.line(img, (x, y - size), (x, y + size), color, 1)
 
 
-def find_all_circles(image_path: str = "IMG_9503.JPG") -> tuple[np.ndarray, Path]:
-    """Detect all circles in ``image_path`` and save an annotated image.
+def process_image(image_path: str = "IMG_9503.JPG") -> tuple[np.ndarray, Path]:
+    """Detect circles, overlay a grid and save an annotated image."""
 
-    Returns
-    -------
-    tuple[np.ndarray, Path]
-        Array of detected circles (x, y, r) and path to the output image.
-    """
-    img = cv2.imread(image_path)
-    if img is None:
-        raise FileNotFoundError(f"{image_path} not found")
+    result = find_center_circle(image_path)
+    if result is None:
+        raise RuntimeError("No center circle detected")
+
+    cx, cy, r, mm_per_pixel, img = result
 
     gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
-    blur = cv2.GaussianBlur(gray, (5, 5), 0)
-    circles = cv2.HoughCircles(
-        blur,
-        cv2.HOUGH_GRADIENT,
-        dp=1.2,
-        minDist=20,
-        param1=100,
-        param2=30,
-        minRadius=5,
-        maxRadius=80,
-    )
+    circles = detect_all_circles(gray, mm_per_pixel)
 
-    if circles is not None:
-        circles = np.round(circles[0]).astype(int)
-        for x, y, r in circles:
-            draw_crosshair(img, (x, y))
-            cv2.circle(img, (x, y), r, (0, 255, 0), 1)
-    else:
+    # Draw the grid first so circle overlays remain visible
+    draw_grid(img, (cx, cy), mm_per_pixel)
+
+    if circles is None:
         circles = np.empty((0, 3), dtype=int)
+    else:
+        for x, y, rad in circles:
+            cv2.circle(img, (x, y), rad, (0, 0, 255), 1)
+            draw_crosshair(img, (x, y))
+
+    # Ensure the detected centre circle is highlighted on top of the grid
+    cv2.circle(img, (cx, cy), r, (0, 0, 255), 1)
+    draw_crosshair(img, (cx, cy))
 
     output_dir = Path.home() / "downloads"
     output_dir.mkdir(parents=True, exist_ok=True)
-    output_path = output_dir / "IMG_9503_circles.png"
+    output_path = output_dir / "IMG_9503_grid.png"
     cv2.imwrite(str(output_path), img)
 
     return circles, output_path
 
 
 if __name__ == "__main__":
-    circles, output_path = find_all_circles()
+    circles, output_path = process_image()
     print(f"Detected {len(circles)} circles")
     print(f"Saved annotated image to {output_path}")

--- a/find_center_circle.py
+++ b/find_center_circle.py
@@ -128,16 +128,18 @@ def detect_all_circles(
     cell_px = cell_mm / mm_per_pixel
     expected_r_px = (1.5) / mm_per_pixel  # 3 mm diameter -> 1.5 mm radius
 
-    blur = cv2.GaussianBlur(gray, (5, 5), 0)
+    blur = cv2.GaussianBlur(gray, (9, 9), 0)
+    kernel = np.ones((3, 3), np.uint8)
+    opened = cv2.morphologyEx(blur, cv2.MORPH_OPEN, kernel)
     circles = cv2.HoughCircles(
-        blur,
+        opened,
         cv2.HOUGH_GRADIENT,
         dp=1.2,
-        minDist=int(cell_px * 0.8),
-        param1=100,
-        param2=30,
-        minRadius=int(expected_r_px * 0.7),
-        maxRadius=int(expected_r_px * 1.3),
+        minDist=int(cell_px * 0.9),
+        param1=150,
+        param2=60,
+        minRadius=int(expected_r_px * 0.9),
+        maxRadius=int(expected_r_px * 1.1),
     )
 
     if circles is not None:


### PR DESCRIPTION
## Summary
- Apply stronger Gaussian blur and morphological opening before Hough detection
- Increase minimum distance, radius limits, and param thresholds to suppress false circles

## Testing
- `pip install opencv-python-headless numpy -r requirements.txt`
- `python find_all_circles.py`


------
https://chatgpt.com/codex/tasks/task_e_689ad532ad808329b8b5816d86ff1c57