### PR TITLE
Refine circle detection thresholds and centre highlight

### DIFF
--- a/find_all_circles.py
+++ b/find_all_circles.py
@@ -45,8 +45,8 @@ def process_image(image_path: str = "04_unsharp.png") -> tuple[np.ndarray, Path]
             draw_crosshair(img, (x, y))
 
     # Ensure the detected centre circle is highlighted on top of the grid
-    cv2.circle(img, (cx, cy), r, (0, 0, 255), 1)
-    draw_crosshair(img, (cx, cy))
+    cv2.circle(img, (cx, cy), r, (0, 255, 255), 1)
+    draw_crosshair(img, (cx, cy), color=(0, 255, 255))
 
     output_dir = Path.home() / "downloads"
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/find_center_circle.py
+++ b/find_center_circle.py
@@ -83,7 +83,7 @@ def draw_grid(
     img: np.ndarray,
     center: tuple[int, int],
     mm_per_pixel: float,
-    cell_mm: float = 4.0,
+    cell_mm: float = 4.5,
     offset_mm: float = 2.0,
 ) -> None:
     """Overlay a square grid on ``img`` centred around ``center``.
@@ -111,7 +111,7 @@ def draw_grid(
 
 
 def detect_all_circles(
-    gray: np.ndarray, mm_per_pixel: float, cell_mm: float = 4.0
+    gray: np.ndarray, mm_per_pixel: float, cell_mm: float = 4.5
 ) -> np.ndarray | None:
     """Detect all circles in ``gray`` using Hough transform.
 
@@ -135,9 +135,9 @@ def detect_all_circles(
         opened,
         cv2.HOUGH_GRADIENT,
         dp=1.2,
-        minDist=int(cell_px * 0.8),
+        minDist=int(cell_px * 0.9),
         param1=120,
-        param2=40,
+        param2=50,
         minRadius=int(expected_r_px * 0.85),
         maxRadius=int(expected_r_px * 1.15),
     )
@@ -151,7 +151,7 @@ def compute_offsets(
     circles: np.ndarray,
     center: tuple[int, int],
     mm_per_pixel: float,
-    cell_mm: float = 4.0,
+    cell_mm: float = 4.5,
 ) -> list[dict[str, float | str | int]]:
     """Compute positional offsets of circles from their ideal grid points."""
 

--- a/find_circles_and_ovals.py
+++ b/find_circles_and_ovals.py
@@ -19,7 +19,7 @@ def draw_crosshair(
 
 
 def detect_ellipses(
-    gray: np.ndarray, mm_per_pixel: float, cell_mm: float = 4.0
+    gray: np.ndarray, mm_per_pixel: float, cell_mm: float = 4.5
 ) -> np.ndarray | None:
     """Detect ovals (ellipses) in ``gray`` using contour fitting."""
 
@@ -89,8 +89,8 @@ def process_image(
             draw_crosshair(img, (int(x), int(y)))
 
     # Highlight centre circle on top of the grid
-    cv2.circle(img, (cx, cy), r, (0, 0, 255), 1)
-    draw_crosshair(img, (cx, cy))
+    cv2.circle(img, (cx, cy), r, (0, 255, 255), 1)
+    draw_crosshair(img, (cx, cy), color=(0, 255, 255))
 
     output_dir = Path.home() / "downloads"
     output_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Adjust grid spacing and circle/oval detectors to expect 4.5 mm cell spacing
- Tighten Hough circle parameters to reduce duplicate detections
- Highlight centre circle in yellow for easier identification

## Testing
- `python -m py_compile find_all_circles.py find_center_circle.py find_circles_and_ovals.py`


------
https://chatgpt.com/codex/tasks/task_e_689c39b30b3083298b6fa51baffd34ba